### PR TITLE
Fixed tests + better map, find and until

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
   "bugs": {
     "url": "https://github.com/gyllstromk/q-plus-plus/issues"
   },
-  "devDependencies": {
-    "mocha": "~1.14.0",
-    "chai": "~1.8.1"
-  },
   "dependencies": {
     "q": "^1.1.1"
+  },
+  "devDependencies": {
+    "chai": "^1.10.0",
+    "chai-as-promised": "^4.1.1",
+    "mocha": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-flow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Flow control (loops, arrays, etc) with promises and Q.",
   "main": "q-flow.js",
   "scripts": {
@@ -25,6 +25,6 @@
     "chai": "~1.8.1"
   },
   "dependencies": {
-    "q": "~0.9.7"
+    "q": "^1.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,58 +2,147 @@
 
 require('./');
 
-var q      = require('q'),
-    expect = require('chai').expect;
+var q              = require('q'),
+    chai           = require("chai"),
+    chaiAsPromised = require("chai-as-promised");
+    expect         = chai.expect;
+
+chai.should();
+chai.use(chaiAsPromised);
+
 
 describe('q-flow', function () {
-    it('each', function (done) {
-        var sum = 0;
+    describe('each', function () {
+        it('works with promises', function () {
+            var sum = 0;
 
-        return q.each([ 1, 2, 3 ], function (each) {
-            sum += each;
-            return q.when(each);
-        }).then(function (value) {
-            expect(value).to.be.undefined;
-            expect(sum).to.equal(6);
-        }).fin(done);
+            return q.each([1, 2, 3], function (each) {
+                sum += each;
+                return q.when(each);
+            }).then(function (value) {
+                expect(value).to.be.undefined;
+                expect(sum).to.equal(6);
+            }).should.be.fulfilled;
+        });
+
+        it('works without promises', function () {
+            var sum = 0;
+
+            return q.each([1, 2, 3], function (each) {
+                sum += each;
+                return each;
+            }).then(function (value) {
+                expect(value).to.be.undefined;
+                expect(sum).to.equal(6);
+            }).should.be.fulfilled;
+        });
+
+        it('works without return', function () {
+            var sum = 0;
+
+            return q.each([1, 2, 3], function (each) {
+                sum += each;
+            }).then(function (value) {
+                expect(value).to.be.undefined;
+                expect(sum).to.equal(6);
+            }).should.be.fulfilled;
+        });
     });
 
-    it('map', function (done) {
-        return q.each([ 1, 2, 3 ], function (each) {
-            return q.when(each + 1);
-        }).then(function (value) {
-            expect(value).to.deep.equal([ 2, 3, 4 ]);
-        }).fin(done);
+    describe('map', function () {
+        it('works with promises', function () {
+            return q.map([1, 2, 3], function (each) {
+                return q.when(each + 1);
+            }).should.eventually.deep.equal([2, 3, 4]);
+        });
+
+        it('works without promises', function () {
+            return q.map([1, 2, 3], function (each) {
+                return each + 1;
+            }).should.eventually.deep.equal([2, 3, 4]);
+        });
     });
 
-    it('until', function (done) {
-        var attempt = 0;
-        return q.until(function () {
-            return q.fcall(function () {
-                return ++attempt > 3;
-            });
-        }).then(function () {
-            expect(attempt).to.equal(4);
-        }).fin(done);
+    describe('until', function() {
+        it('works', function () {
+            var attempt = 0;
+            return q.until(function () {
+                return q.fcall(function () {
+                    return ++attempt > 3;
+                });
+            }).then(function () {
+                expect(attempt).to.equal(4);
+            }).should.be.fulfilled;
+        });
+
+        it('passes if we do less than max tries', function () {
+            var attempt = 0;
+            return q.until(function () {
+                return q.fcall(function () {
+                    return ++attempt > 3;
+                });
+            }, undefined, 4).should.be.fulfilled;
+        });
+
+        it('throws an exception if we do more than max tries', function () {
+            var attempt = 0;
+            return q.until(function () {
+                return q.fcall(function () {
+                    return ++attempt > 3;
+                });
+            }, undefined, 3).should.be.rejected;
+        });
+
+        it('waits if we set a delay', function () {
+            var attempt = 0;
+            var start = new Date();
+
+            return q.until(function () {
+                return q.fcall(function () {
+                    return ++attempt > 3;
+                });
+            }, 100).then(function () {
+                var end = new Date();
+                var elapse = end - start;
+                expect(elapse).to.be.above(200);
+                expect(elapse).to.be.below(400);
+            }).should.be.fulfilled;
+        });
     });
 
     describe('find', function () {
-        var fn = function (each) {
-            return q.fcall(function () {
-                return each >= 3;
+        describe('with promise', function () {
+            var fn = function (each) {
+                return q.fcall(function () {
+                    return each >= 3;
+                });
+            };
+
+            it('returns first match', function () {
+                return q.find([1, 2, 3, 4, 5], fn)
+                    .should.eventually.deep.equal(3);
+            })
+
+            it('results undefined if nothing matches', function () {
+                return q.find([1, 1, 1, 1, 1], fn)
+                    .should.eventually.be.undefined;
             });
-        };
+        });
 
-        it('returns first match', function (done) {
-            return q.find([ 1, 2, 3, 4, 5 ], fn).then(function (item) {
-                expect(item).to.equal(3);
-            }).fin(done);;
-        })
+        describe('without promise', function () {
+            var fn = function (each) {
+                return each >= 3;
+            };
 
-        it('results undefined if nothing matches', function (done) {
-            return q.find([1, 1, 1, 1, 1 ], fn).then(function (item) {
-                expect(item).to.be.undefined;
-            }).fin(done);
+            it('returns first match', function () {
+                return q.find([1, 2, 3, 4, 5], fn)
+                    .should.eventually.deep.equal(3);
+            })
+
+            it('results undefined if nothing matches', function () {
+                return q.find([1, 1, 1, 1, 1], fn)
+                    .should.eventually.be.undefined;
+            });
         });
     });
 


### PR DESCRIPTION
- Updated tests to use chai-as-promised since they were not failing when
  expected to fail (i.e. map test was testing each and should have failed
  and didn't).
- Updated map and find to support a function returning a promise or not.
- Updated until to support max tries and delay between tries.
- Includes gyllstromk/q-plus-plus#4
